### PR TITLE
Update travis file + hotfix for manifest.yml to address VCAP Service problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
 
 services:
   - postgresql
-  - availability-monitoring-auto
   - continuous-delivery-nyu-delta-team-f17
   - elephantsql-nyu-delta-team-f17
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,8 @@ env:
 
 services:
   - postgresql
+  - availability-monitoring-auto
+  - continuous-delivery-nyu-delta-team-f17
+  - elephantsql-nyu-delta-team-f17
+
 

--- a/connection.py
+++ b/connection.py
@@ -3,37 +3,44 @@ import json
 import logging
 
 def get_database_uri():
-    """
-    Initialized ElephantSQL database connection
+  """
+  Initialized ElephantSQL database connection
 
-    This method will work in the following conditions:
-      1) In Bluemix with ElephantSQL bound through VCAP_SERVICES
-      2) With ElephantSQL running on the local server as with Travis CI
-      3) With PostgresSQL --link in a Docker container called 'postgres'
-      4) Passing in your own ElephantSQL connection object
+  This method will work in the following conditions:
+    1) In Bluemix with ElephantSQL bound through VCAP_SERVICES
+    2) With ElephantSQL running on the local server as with Travis CI
+    3) With PostgresSQL --link in a Docker container called 'postgres'
+    4) Passing in your own ElephantSQL connection object
 
-    Exception:
-    ----------
-      OperationalError - if connect() fails
-    """
+  Exception:
+  ----------
+    OperationalError - if connect() fails
+  """
 
-    if 'VCAP_SERVICES' in os.environ:
-        # Get the credentials from the Bluemix environment
-        logging.info("Using VCAP_SERVICES...")
-        vcap_services = os.environ['VCAP_SERVICES']
-        services = json.loads(vcap_services)
-        creds = services['elephantsql'][0]['credentials']
-        uri = creds["uri"]
+  if 'VCAP_SERVICES' in os.environ:
+    # Get the credentials from the Bluemix environment
+    logging.info("Using VCAP_SERVICES...")
+    vcap_services = os.environ['VCAP_SERVICES']
+    services = json.loads(vcap_services)
+    creds = services['elephantsql'][0]['credentials']
+    uri = creds["uri"]
 
-     else:
-        logging.info("Using localhost database...")
-        name = 'postgres'
+  else:
+    logging.info("Using localhost database...")
+    username = 'postgres'
+    password = 'password'
+    hostname = 'localhost'
+    port = '5432'
+
+    #default to development
+    name = 'development'
+
+    if 'TEST' in os.environ:
+        name = 'test'
         
-        if 'TEST' in os.environ:
-            name = 'test'
-        else:
-            name = 'development'
-        uri = 'postgres://postgres:password@localhost:5432/{}'
-        uri.format(name)
 
-    return uri
+    logging.info("Conecting to database on host %s port %s", hostname, port)
+    uri = 'postgres://{}:{}@{}:{}/{}'
+    uri = uri.format(username, password, hostname, port, name)
+  
+  return uri

--- a/connection.py
+++ b/connection.py
@@ -23,11 +23,9 @@ def get_database_uri():
         vcap_services = os.environ['VCAP_SERVICES']
         services = json.loads(vcap_services)
         creds = services['elephantsql'][0]['credentials']
-        username = creds["username"]
-        password = creds["password"]
-        hostname = creds["hostname"]
-        port = creds["port"]
-        name = creds["name"]
+        uri = creds["uri"]
+        max_conns = creds["max_conns"]
+        return uri
 
     else:
         logging.info("Using localhost database...")

--- a/connection.py
+++ b/connection.py
@@ -24,21 +24,16 @@ def get_database_uri():
         services = json.loads(vcap_services)
         creds = services['elephantsql'][0]['credentials']
         uri = creds["uri"]
-        max_conns = creds["max_conns"]
-        return uri
 
-    else:
+     else:
         logging.info("Using localhost database...")
-        username = 'postgres'
-        password = 'password'
-        hostname = 'localhost'
-        port = '5432'
-
+        name = 'postgres'
+        
         if 'TEST' in os.environ:
             name = 'test'
         else:
             name = 'development'
+        uri = 'postgres://postgres:password@localhost:5432/{}'
+        uri.format(name)
 
-    logging.info("Conecting to database on host %s port %s", hostname, port)
-    connect_string = 'postgres://{}:{}@{}:{}/{}'
-    return connect_string.format(username, password, hostname, port, name)
+    return uri

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,4 +12,3 @@ applications:
   services:
   - elephantsql-nyu-delta-team-f17
   - availability-monitoring-auto
-  - continuous-delivery-nyu-delta-team-f17	

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,4 +11,3 @@ applications:
   buildpack: python_buildpack
   services:
   - elephantsql-nyu-delta-team-f17
- # - availability-monitoring-auto

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,4 +11,4 @@ applications:
   buildpack: python_buildpack
   services:
   - elephantsql-nyu-delta-team-f17
-  - availability-monitoring-auto
+ # - availability-monitoring-auto

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,3 +12,4 @@ applications:
   services:
   - elephantsql-nyu-delta-team-f17
   - availability-monitoring-auto
+  - continuous-delivery-nyu-delta-team-f17	


### PR DESCRIPTION
While updating the .travis.yml file, I discovered that there was a problem with our Bluemix server. This was because the VCAP Services key:val pair was modified during a previous merge. I also noticed that we were not using Continuous Availability, so I decided to remove the service temporarily from the manifest.yml file. In addition, I also added continuous delivery and elephant sql to our .travis.yml file under the services field. This was my initial intention when creating this issue. However, I decided to enclose the two as a single issue since they were to some degree related (the services that we would be adding to the .travis.yml were broken).